### PR TITLE
V24 | IOS-3733 | Keyboard is disappearing if use autocomplete as first input during creation flow

### DIFF
--- a/FLTextView/FLTextView.swift
+++ b/FLTextView/FLTextView.swift
@@ -395,8 +395,8 @@ extension FLTextView: UITextViewDelegate {
                 if let frozenText = frozenPrefix where placeholderView.isFirstResponder() {
                     placeholderView.userInteractionEnabled = false
                     placeholderView.resignFirstResponder()
-                    self.text = frozenText + text
                     becomeFirstResponder()
+                    self.text = frozenText + text
                     if isExternalTextViewDelegateRespondsToSelector(#selector(UITextViewDelegate.textViewDidChange(_:))) {
                         externalTextViewDelegate!.textViewDidChange!(self)
                     }


### PR DESCRIPTION
Solution is not elegant but works
